### PR TITLE
Support for python 2.4

### DIFF
--- a/pusher/__init__.py
+++ b/pusher/__init__.py
@@ -1,9 +1,31 @@
-import httplib, time, hashlib, hmac, base64
+import httplib, time, sys, hmac
 
 try:
     import json
+    # some old versions of json lib don't implement dumps()
+    if not hasattr(json, "dumps"):
+        raise ImportError
 except ImportError:
     import simplejson as json
+
+# 2.4 hashlib implementation: http://code.krypto.org/python/hashlib/
+import hashlib
+
+md5_constructor = hashlib.md5
+sha_constructor = hashlib.sha256
+
+# But 2.4 hmac isn't compatible with hashlib.sha256 so use this wrapper
+# http://www.schwarz.eu/opensource/projects/trac_captcha/browser/trac_captcha/cryptobox.py?rev=79%3Aed771e5252dc#L34
+class AlgorithmWrapper(object):
+    def __init__(self, algorithm):
+        self.algorithm = algorithm
+        self.digest_size = self.algorithm().digest_size
+
+    def new(self, *args, **kwargs):
+        return self.algorithm(*args, **kwargs)
+
+if sys.version_info < (2, 5):
+    sha_constructor = AlgorithmWrapper(hashlib.sha256)
 
 host    = 'api.pusherapp.com'
 port    = 80
@@ -51,11 +73,12 @@ class Channel(object):
     def signed_query(self, event, json_data, socket_id):
         query_string = self.compose_querystring(event, json_data, socket_id)
         string_to_sign = "POST\n%s\n%s" % (self.path, query_string)
-        signature = hmac.new(self.pusher.secret, string_to_sign, hashlib.sha256).hexdigest()
+        signature = hmac.new(self.pusher.secret, string_to_sign, sha_constructor).hexdigest()
+        print "signed_query", "%s&auth_signature=%s" % (query_string, signature)
         return "%s&auth_signature=%s" % (query_string, signature)
 
     def compose_querystring(self, event, json_data, socket_id):
-        hasher = hashlib.md5()
+        hasher = md5_constructor()
         hasher.update(json_data)
         hash_str = hasher.hexdigest()
         ret = "auth_key=%s&auth_timestamp=%s&auth_version=1.0&body_md5=%s&name=%s" % (self.pusher.key, int(time.time()), hash_str, event)
@@ -65,6 +88,7 @@ class Channel(object):
 
     def send_request(self, query_string, data_string):
         signed_path = '%s?%s' % (self.path, query_string)
+        print "send_request", signed_path
         http = httplib.HTTPConnection(self.pusher.host, self.pusher.port)
         http.request('POST', signed_path, data_string, {'Content-Type': 'application/json'})
         return http.getresponse().status
@@ -90,7 +114,7 @@ class Channel(object):
       if custom_string:
         string_to_sign += ":%s" % custom_string
 
-      signature = hmac.new(self.pusher.secret, string_to_sign, hashlib.sha256).hexdigest()
+      signature = hmac.new(self.pusher.secret, string_to_sign, sha_constructor).hexdigest()
 
       return "%s:%s" % (self.pusher.key,signature)
 
@@ -105,15 +129,15 @@ class GoogleAppEngineChannel(Channel):
             headers={'Content-Type': 'application/json'}
         )
         return response.status_code
-        
+
 class TornadoChannel(Channel):
     def trigger(self, event, data={}, socket_id=None, callback=None):
         self.callback = callback
         return super(TornadoChannel, self).trigger(event, data, socket_id)
-        
+
     def send_request(self, query_string, data_string):
         import tornado.httpclient
-        signed_path = '%s?%s' % (self.path, query_string)
+#        signed_path = '%s?%s' % (self.path, query_string)
         absolute_url = 'http://%s/%s?%s' % (self.pusher.host, self.path, query_string)
         request = tornado.httpclient.HTTPRequest(absolute_url, method='POST', body=data_string)
         client = tornado.httpclient.AsyncHTTPClient()


### PR DESCRIPTION
Python 2.4 doesn't have hashlib and its version of hmac aren't compatible with this package. Here's the traceback that is generated:

File ".../pusher/init.py", line 55, in trigger
status = self.sendrequest(self.signed_query(event, json_data, socket_id), json_data)
File ".../pusher/init.py", line 68, in signed_query
signature = hmac.new(self.pusher.secret, string_to_sign, sha_constructor).hexdigest()
File "/usr/local/lib/python2.4/hmac.py", line 107, in new
return HMAC(key, msg, digestmod)
File "/usr/local/lib/python2.4/hmac.py", line 42, in __init_
self.outer = digestmod.new()
AttributeError: 'builtin_function_or_method' object has no attribute 'new'

This pull request contains the patch
