### PR TITLE
Add support for URLs, especially in Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Credentials can also be set in a per-instance basis:
 
     p = pusher.Pusher(app_id='your-pusher-app-id', key='your-pusher-key', secret='your-pusher-secret')
 
+## Heroku
+
+If you're using Pusher as a Heroku add-on, you can just get the config informat
+
+    p = pusher.pusher_from_url()
+
 ## Tornado
 
 To use the Tornado web server to trigger events, set `channel_type`:

--- a/pusher/__init__.py
+++ b/pusher/__init__.py
@@ -32,6 +32,19 @@ app_id  = None
 key     = None
 secret  = None
 
+def url2options(url):
+    assert url.startswith('http://'), "invalid URL"
+    url = url[7:]
+    key, url = url.split(':', 1)
+    secret, url = url.split('@', 1)
+    host, url = url.split('/', 1)
+    url, app_id = url.split('/', 1)
+    return {'key': key, 'secret': secret, 'host': host, 'app_id': app_id}
+
+def pusher_from_url(url=None):
+    url = url or os.environ['PUSHER_URL']
+    return Pusher(**url2options(url))
+
 class Pusher(object):
     def __init__(self, app_id=None, key=None, secret=None, host=None, port=None):
         _globals = globals()


### PR DESCRIPTION
This patch will make it easier for people using pusher via Heroku to connect to the pusher server. Heroku puts the pusher config information in one long URL in the environment; this pulls it out and parses it the way the Pusher Python client wants.
