### PR TITLE
Fix pusher_from_url()

### DIFF
--- a/pusher/__init__.py
+++ b/pusher/__init__.py
@@ -10,6 +10,7 @@ except ImportError:
 
 # 2.4 hashlib implementation: http://code.krypto.org/python/hashlib/
 import hashlib
+import os
 
 sha_constructor = hashlib.sha256
 


### PR DESCRIPTION
`pusher_from_url()` raised "NameError: global name 'os' is not defined" because `import os` was missing. This PR fixes this.
