### PR TITLE
including setuptools in requirements is redundant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,4 @@ setup(
     ],
     keywords='pusher rest realtime websockets service',
     license='MIT',
-    install_requires=[
-        'setuptools',
-    ],
 )


### PR DESCRIPTION
It also breaks pip install that are against a list of multiple packages (like requirements.txt on heroku).
