### PR TITLE
 'Fixed' tests

### DIFF
--- a/pusher/pusher.py
+++ b/pusher/pusher.py
@@ -227,7 +227,7 @@ class Pusher(object):
         if custom_data:
             string_to_sign += ":%s" % custom_data
 
-        signature = sign(self.secret, string_to_sign)
+        signature = sign(self.secret.encode('utf8'), string_to_sign.encode('utf8'))
 
         auth = "%s:%s" % (self.key, signature)
         result = {'auth': auth}
@@ -257,7 +257,7 @@ class Pusher(object):
         if key != self.key:
             return None
 
-        if not verify(self.secret, body, signature):
+        if not verify(self.secret.encode('utf8'), body.encode('utf8'), signature):
             return None
 
         try:

--- a/pusher/signature.py
+++ b/pusher/signature.py
@@ -16,8 +16,8 @@ except AttributeError:
 def sign(secret, string_to_sign):
 	return six.text_type(
 		hmac.new(
-				secret.encode('utf8'),
-				string_to_sign.encode('utf8'),
+				secret,
+				string_to_sign,
 				hashlib.sha256
 			)
 			.hexdigest()

--- a/pusher/sync.py
+++ b/pusher/sync.py
@@ -16,6 +16,8 @@ class SynchronousBackend(object):
     """
     def __init__(self, config):
         if config.ssl:
+            if sys.version_info < (3,4):
+                raise NotImplementedError("SSL requires python >= 3.4, earlier versions don't support certificate validation")
             ctx = ssl.create_default_context()
             self.http = http_client.HTTPSConnection(config.host, config.port, timeout=config.timeout, context=ctx)
         else:


### PR DESCRIPTION
I'm not 100% sure about this - I'm not even *completely* sure why it fixes the tests.

Basically `ssl#create_default_context` is new to python 3.4

Regarding the changes in the `#sign` method it was coming out with 'bytes has no attribute encode'. Encoding it before passing it to the sign method seems to work, for some reason.

The `verify` method was expecting bytes but getting strings, so again I encoded before passing it to the method