### PR TITLE
Fix incorrect authenticate method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ auth = pusher.authenticate(
 ###### Presence Channels
 
 ```python
-auth = pusher.authenticate_subscription(
+auth = pusher.authenticate(
 
   channel=u"presence-channel",
 


### PR DESCRIPTION
Just fixing the README in regards to authenticating presence channels. Wrong method name was listed. 