### PR TITLE
Added note on readme about pip install with aiohttp. Addresses #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ normally `easy_install` or `pip`. For example:
 pip install pusher
 ```
 
+Users on Python 2.x and older versions of pip may get a warning, due to pip compiling the optional `pusher.aiohttp` module, which uses Python 3 syntax. However, as `pusher.aiohttp` is not used by default, this does not affect the library's functionality. See [our Github issue](https://github.com/pusher/pusher-http-python/issues/52), as well as [this issue from Gunicorn](https://github.com/benoitc/gunicorn/issues/788) for more details.
+
 Getting started
 ---------------
 


### PR DESCRIPTION
'Users on Python 2.x and older versions of pip may get a warning, due to pip compiling the optional `pusher.aiohttp` module, which uses Python 3 syntax. However, as `pusher.aiohttp` is not used by default, this does not affect the library's functionality. See [our Github issue](https://github.com/pusher/pusher-http-python/issues/52), as well as [this issue from Gunicorn](https://github.com/benoitc/gunicorn/issues/788) for more details.'

wdyt @zimbatm ?