### PR TITLE
Wheel file upload support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 
 publish:
 	python setup.py register
-	python setup.py sdist upload
-	python setup.py bdist_wheel upload
+	python setup.py sdist bdist_wheel upload
 
 .PHONY: publish

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[metadata]
+description-file = README.md
+
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 setup(
     name='pusher',
-    version='1.2.1',
+    version='1.2.2',
     description='A Python library to interract with the Pusher API',
     url='https://github.com/pusher/pusher-http-python',
     author='Pusher',


### PR DESCRIPTION
Our earlier version wasn't uploading a `.whl` file for some reason. This PR contains changes that ensure the wheel file is published to PyPI.

> Submitting /Users/leggetter/pusher/git/pusher-http-python/dist/pusher-1.2.2-py2.py3-none-any.whl to https://pypi.python.org/pypi

http://pythonwheels.com/