### PR TITLE
GAE Backend loading issues

### DIFF
--- a/pusher/pusher.py
+++ b/pusher/pusher.py
@@ -4,7 +4,6 @@ from __future__ import (print_function, unicode_literals, absolute_import,
                         division)
 from pusher.http import GET, POST, Request, request_method
 from pusher.signature import sign, verify
-from pusher.requests import RequestsBackend
 from pusher.util import ensure_text, validate_channel, validate_socket_id, app_id_re, pusher_url_re, channel_name_re
 
 import collections
@@ -37,7 +36,12 @@ class Pusher(object):
     :param backend_options: additional backend
     """
     def __init__(self, app_id, key, secret, ssl=True, host=None, port=None, timeout=5, cluster=None,
-                 json_encoder=None, json_decoder=None, backend=RequestsBackend, **backend_options):
+                 json_encoder=None, json_decoder=None, backend=None, **backend_options):
+
+        if backend is None:
+            from pusher.requests import RequestsBackend
+            backend = RequestsBackend
+
         self._app_id = ensure_text(app_id, "app_id")
         if not app_id_re.match(self._app_id):
             raise ValueError("Invalid app id")


### PR DESCRIPTION
When I try to import pusher on my GAE project, I'm getting a stack trace something like this:

      ...
      File "my-project/mymodule.py", line 10, in <module>
        from pusher import Pusher
      File "lib/pusher/__init__.py", line 3, in <module>
        from .pusher import Pusher
      File "lib/pusher/pusher.py", line 7, in <module>
        from pusher.requests import RequestsBackend
      File "lib/pusher/requests.py", line 12, in <module>
        import urllib3.contrib.pyopenssl
      File "lib/urllib3/contrib/pyopenssl.py", line 48, in <module>
        from ndg.httpsclient.ssl_peer_verification import SUBJ_ALT_NAME_SUPPORT
    ImportError: No module named ndg.httpsclient.ssl_peer_verification

This seems to be some issue around GAE not including the necessary modules that `RequestsBackend` requires.

This patch changes the default backend behaviour such that it only imports the default if one wasn't specified in the constructor (avoiding this issue for GAE users, and potentially others that don't have requests installed).
