### PR TITLE
Correctly handle default for Request params

### DIFF
--- a/pusher/http.py
+++ b/pusher/http.py
@@ -63,7 +63,9 @@ class Request(object):
     :param path: The target path on the destination host
     :param params: Query params or body depending on the method
     """
-    def __init__(self, config, method, path, params={}):
+    def __init__(self, config, method, path, params=None):
+        if params is None:
+            params = {}
         self.config = config
         self.method = method
         self.path = path


### PR DESCRIPTION
I was having issues where the signature calculated was incorrect for GET methods that didn't have params (e.g. `pusher.users_info(channel)`)

I discovered the reason is that the default params is being reused, and the second call to the method still has the `auth_signature` from the last call present (which causes this call to have an incorrectly calculated signature).