### PR TITLE
Add explicit support python 2 and 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ setup(
     author='Pusher',
     author_email='support@pusher.com',
     classifiers=[
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python",
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Topic :: Internet :: WWW/HTTP",
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Topic :: Internet :: WWW/HTTP',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ],
@@ -46,7 +46,7 @@ setup(
     tests_require=['nose', 'mock', 'HTTPretty'],
 
     extras_require={
-        'aiohttp': ["aiohttp>=0.9.0"],
+        'aiohttp': ['aiohttp>=0.9.0'],
         'tornado': ['tornado>=4.0.0']
     },
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Topic :: Internet :: WWW/HTTP",
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
     ],
     keywords='pusher rest realtime websockets service',
     license='MIT',


### PR DESCRIPTION
Just adds classifiers in the setup.py as requested by https://github.com/pusher/pusher-http-python/issues/76.