### PR TITLE
update max channel from 10 too 100

### DIFF
--- a/pusher/pusher_client.py
+++ b/pusher/pusher_client.py
@@ -57,7 +57,7 @@ class PusherClient(Client):
                 channels, (collections.Sized, collections.Iterable)):
             raise TypeError("Expected a single or a list of channels")
 
-        if len(channels) > 10:
+        if len(channels) > 100:
             raise ValueError("Too many channels")
 
         channels = list(map(validate_channel, channels))


### PR DESCRIPTION
We can send message to max 100 channels in one request.

reference：https://pusher.com/docs/rest_api#method-post-event