### PR TITLE
Revert "Test versions 3.5 and 3.6 with travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 ---
 language: python
 python:
+  - "2.6"
   - "2.7"
+  - "3.3"
   - "3.4"
-  - "3.5"
-  - "3.6"
 before_install:
   - pip install --upgrade setuptools
 install: 
   - "python setup.py develop"
-  - "if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install aiohttp; fi"
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install aiohttp==0.17.4; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then pip install aiohttp; fi
   - "pip install tornado"
   - "pip install urlfetch"
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
 script: "python setup.py test"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In order to use this library, you need to have a free account on <http://pusher.
 
 ## Features
 
-* Python 2.7, 3.4, 3.5 and 3.6 support
+* Python 2.6, 2.7 and 3.3 support
 * Adapters for various http libraries like requests, urlfetch, aiohttp and tornado.
 * WebHook validation
 * Signature generation for socket subscriptions

--- a/pusher_tests/test_request.py
+++ b/pusher_tests/test_request.py
@@ -4,7 +4,6 @@ from __future__ import print_function, absolute_import, division
 
 import unittest
 import re
-import sys
 
 from pusher import Pusher
 from pusher.http import Request
@@ -51,16 +50,27 @@ class TestRequest(unittest.TestCase):
 
             json_dumps_mock.assert_called_once_with({u"foo": u"bar"})
 
+    # Copied wholesale from https://github.com/python/cpython/blob/2d305e1c46abfcd609bf8b2dff8d2065e6af8ab2/Lib/unittest/case.py#L1279-L1289
+    # This can be removed when we no longer support Python 2.6
+    def assertRegexpMatches(self, text, expected_regex, msg=None):
+        """Fail the test unless the text matches the regular expression."""
+        if isinstance(expected_regex, (str, bytes)):
+            assert expected_regex, "expected_regex must not be empty."
+            expected_regex = re.compile(expected_regex)
+        if not expected_regex.search(text):
+            standardMsg = "Regex didn't match: %r not found in %r" % (
+                expected_regex.pattern, text)
+            # _formatMessage ensures the longMessage option is respected
+            msg = self._formatMessage(msg, standardMsg)
+            raise self.failureException(msg)
+
     def test_x_pusher_library_header(self):
         conf = Pusher.from_url(u'http://key:secret@somehost/apps/4')
         req = Request(conf._pusher_client, u'GET', u'/some/obscure/api', {u'foo': u'bar'})
         self.assertTrue('X-Pusher-Library' in req.headers)
         pusherLib = req.headers['X-Pusher-Library']
-        regex = r'^pusher-http-python \d+(\.\d+)+(rc\d+)?$'
-        if sys.version_info < (3,):
-            self.assertRegexpMatches(pusherLib, regex)
-        else:
-            self.assertRegex(pusherLib, regex)
+        self.assertRegexpMatches(pusherLib, r'^pusher-http-python \d+(\.\d+)+(rc\d+)?$')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Reverts pusher/pusher-http-python#110 because travis is now failing on master, and I'm not sure why.