### PR TITLE
Require Python 3.5.3 for aiohttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In order to use this library, you need to have a free account on <http://pusher.
 ## Features
 
 * Python 2.7, 3.4, 3.5 and 3.6 support
-* Adapters for various http libraries like requests, urlfetch, aiohttp and tornado.
+* Adapters for various http libraries like requests, urlfetch, aiohttp (requires Python >= 3.5.3) and tornado.
 * WebHook validation
 * Signature generation for socket subscriptions
 

--- a/pusher_tests/test_aiohttp_adapter.py
+++ b/pusher_tests/test_aiohttp_adapter.py
@@ -1,4 +1,4 @@
 import sys
 
-if sys.version_info >= (3,3):
+if sys.version_info >= (3,5,3):
     from .aio.aiohttp_adapter_test import *


### PR DESCRIPTION
This should fix the confusing error in the travis tests.

Turns out [aiohttp requires Python >= 3.5.3](https://github.com/aio-libs/aiohttp#requirements).

Really we should be pinning test dependencies, but at least this makes us aware of breaking changes from upstream packages sooner...