### PR TITLE
Properly close aiohttp sessions

### DIFF
--- a/pusher/aiohttp.py
+++ b/pusher/aiohttp.py
@@ -40,4 +40,4 @@ class AsyncIOBackend:
             if response is not None:
                 response.close()
             if session is not None:
-                session.close()
+                yield from session.close()


### PR DESCRIPTION
ClientSession.close() was always supposed to be awaited on. From aiohttp v3.0.0 onwards, not awaiting on the returned coroutine object is especially damning since the session does not get closed at all.