### PR TITLE
Use tornado.concurrent.Future instead of tornado.concurrent.Traceback.Future

### DIFF
--- a/pusher/tornado.py
+++ b/pusher/tornado.py
@@ -10,7 +10,7 @@ import six
 import tornado
 import tornado.httpclient
 
-from tornado.concurrent import TracebackFuture
+from tornado.concurrent import Future
 
 from pusher.http import process_response
 
@@ -30,7 +30,7 @@ class TornadoBackend(object):
         method = request.method
         data = request.body
         headers = {'Content-Type': 'application/json'}
-        future = TracebackFuture()
+        future = Future()
 
         def process_response_future(response):
             if response.exc_info() is not None:

--- a/pusher/tornado.py
+++ b/pusher/tornado.py
@@ -33,10 +33,7 @@ class TornadoBackend(object):
         future = Future()
 
         def process_response_future(response):
-            if response.exc_info() is not None:
-                future.set_exc_info(response.exc_info())
-
-            elif response.exception() is not None:
+            if response.exception() is not None:
                 future.set_exception(response.exception())
 
             else:

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
 
     extras_require={
         'aiohttp': ['aiohttp>=0.20.0'],
-        'tornado': ['tornado>=4.0.0']
+        'tornado': ['tornado>=5.0.0']
     },
 
     package_data={


### PR DESCRIPTION
tornado.concurrent.Future superceded tornado.concurrent.TracebackFuture
in Tornado 4.0. tornado.concurrent.TracebackFuture has been removed in
Tornado 5.x.

Fixes https://github.com/pusher/pusher-http-python/issues/115