### PR TITLE
Pin travis deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,5 @@ python:
 before_install:
   - pip install --upgrade setuptools
 install: 
-  - "python setup.py develop"
-  - "if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install aiohttp; fi"
-  - "pip install tornado"
-  - "pip install urlfetch"
+  - "pip install -r requirements.txt"
 script: "python setup.py test"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,25 @@
+
+asn1crypto==0.24.0
+certifi==2018.10.15
+cffi==1.11.5
+chardet==3.0.4
+cryptography==2.3.1
+httpretty==0.9.5
+idna==2.7
+mock==2.0.0
+ndg-httpsclient==0.5.1
+nose==1.3.7
+pbr==5.0.0
+pyasn1==0.4.4
+pycparser==2.19
+pyOpenSSL==18.0.0
+requests==2.20.0
+six==1.11.0
+tornado==5.1.1
+urllib3==1.24
+aiohttp==3.4.4; python_version >= '3.5'
+async-timeout==3.0.1; python_version >= '3.5'
+attrs==18.2.0; python_version >= '3.5'
+idna-ssl==1.1.0; python_version >= '3.5' and python_version < '3.7'
+multidict==4.4.2; python_version >= '3.5'
+yarl==1.2.6; python_version >= '3.5'


### PR DESCRIPTION
Currently our tests use the latest version of all dependencies, and this can easily break when a dependency is updated out of the bounds of another dependency. For testing I think we should pin dependencies to a working set. The disadvantage is we will have to manually update this list.