### PR TITLE
Pass kwarg options to HTTPRequest instead of AsyncHTTPClient

### DIFF
--- a/pusher/tornado.py
+++ b/pusher/tornado.py
@@ -18,12 +18,13 @@ from pusher.http import process_response
 class TornadoBackend(object):
     """Adapter for the tornado.httpclient module.
 
-    :param client:  pusher.Client object
-    :param kwargs:  options for the httpclient.HTTPClient constructor
+    :param client:   pusher.Client object
+    :param options:  options for the httpclient.HTTPClient constructor
     """
-    def __init__(self, client, **kwargs):
+    def __init__(self, client, **options):
         self.client = client
-        self.http = tornado.httpclient.AsyncHTTPClient(**kwargs)
+        self.options = options
+        self.http = tornado.httpclient.AsyncHTTPClient()
 
 
     def send_request(self, request):
@@ -43,8 +44,12 @@ class TornadoBackend(object):
                 future.set_result(process_response(code, body))
 
         request = tornado.httpclient.HTTPRequest(
-            request.url, method=method, body=data, headers=headers,
-            request_timeout=self.client.timeout)
+            request.url,
+            method=method,
+            body=data,
+            headers=headers,
+            request_timeout=self.client.timeout,
+            **self.options)
 
         response_future = self.http.fetch(request, raise_error=False)
         response_future.add_done_callback(process_response_future)


### PR DESCRIPTION
We shouldn't be passing these options to the `AsyncHTTPClient`.
The docs state:

> Unless force_instance=True is used, no arguments should be passed
> to the AsyncHTTPClient constructor

https://www.tornadoweb.org/en/stable/httpclient.html?highlight=AsyncHTTPClient#tornado.httpclient.AsyncHTTPClient

The options instead should be set on the `HTTPRequest`:
https://www.tornadoweb.org/en/branch5.1/httpclient.html#tornado.httpclient.HTTPRequest

This is consistent with how options are passed to the requests
backend.

This will fix https://github.com/pusher/pusher-http-python/issues/123 as any kwargs passed to the `Pusher` constructor will be forwarded to calls to `HTTPRequest`.