### PR TITLE
Pass encryption_master_key to NotificationClient

### DIFF
--- a/pusher/notification_client.py
+++ b/pusher/notification_client.py
@@ -20,10 +20,10 @@ GCM_TTL = 241920
 class NotificationClient(Client):
     def __init__(
             self, app_id, key, secret, ssl=True, host=None, port=None,
-            timeout=30, cluster=None, json_encoder=None, json_decoder=None,
+            timeout=30, cluster=None, encryption_master_key=None, json_encoder=None, json_decoder=None,
             backend=None, **backend_options):
         super(NotificationClient, self).__init__(
-            app_id, key, secret, ssl, host, port, timeout, cluster,
+            app_id, key, secret, ssl, host, port, timeout, cluster, encryption_master_key,
             json_encoder, json_decoder, backend, **backend_options)
 
         if host:

--- a/pusher/pusher.py
+++ b/pusher/pusher.py
@@ -58,7 +58,7 @@ class Pusher(object):
 
         self._notification_client = NotificationClient(
             app_id, key, secret, notification_ssl, notification_host, port,
-            timeout, cluster, json_encoder, json_decoder, backend,
+            timeout, cluster, encryption_master_key, json_encoder, json_decoder, backend,
             **backend_options)
 
 


### PR DESCRIPTION
 - It passes the `encryption_master_key` to the NotificationClient that uses that to initialise the super class.
- It fixes #132