### PR TITLE
Upgrade pinned deps for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,26 @@
 
 asn1crypto==0.24.0
-certifi==2018.10.15
-cffi==1.11.5
+certifi==2019.3.9
+cffi==1.12.3
 chardet==3.0.4
-cryptography==2.3.1
-httpretty==0.9.5
-idna==2.7
+cryptography==2.6.1
+httpretty==0.9.6
+idna==2.8
 mock==2.0.0
 ndg-httpsclient==0.5.1
 nose==1.3.7
-pbr==5.0.0
-pyasn1==0.4.4
+pbr==5.1.3
+pyasn1==0.4.5
 pycparser==2.19
-pynacl==1.3.0
-pyOpenSSL==18.0.0
-requests==2.20.0
-six==1.11.0
-tornado==5.1.1
-urllib3==1.24
-aiohttp==3.4.4; python_version >= '3.5'
+PyNaCl==1.3.0
+pyOpenSSL==19.0.0
+requests==2.21.0
+six==1.12.0
+tornado==6.0.2
+urllib3==1.25.1
+aiohttp==3.5.4; python_version >= '3.5'
 async-timeout==3.0.1; python_version >= '3.5'
-attrs==18.2.0; python_version >= '3.5'
+attrs==19.1.0; python_version >= '3.5'
 idna-ssl==1.1.0; python_version >= '3.5' and python_version < '3.7'
-multidict==4.4.2; python_version >= '3.5'
-yarl==1.2.6; python_version >= '3.5'
+multidict==4.5.2; python_version >= '3.5'
+yarl==1.3.0; python_version >= '3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,11 +16,12 @@ PyNaCl==1.3.0
 pyOpenSSL==19.0.0
 requests==2.21.0
 six==1.12.0
-tornado==6.0.2
 urllib3==1.25.1
 aiohttp==3.5.4; python_version >= '3.5'
 async-timeout==3.0.1; python_version >= '3.5'
 attrs==19.1.0; python_version >= '3.5'
 idna-ssl==1.1.0; python_version >= '3.5' and python_version < '3.7'
 multidict==4.5.2; python_version >= '3.5'
+tornado==5.1.1; python_version < '3.5'
+tornado==6.0.2; python_version >= '3.5'
 yarl==1.3.0; python_version >= '3.5'


### PR DESCRIPTION
- [x] If you have changed dependencies, ensure _both_ `requirements.txt` and `setup.py` have been updated

This fixes a vuln in urllib3: https://nvd.nist.gov/vuln/detail/CVE-2019-11324.