### PR TITLE
Updated pusher/pusher.py, pusher/pusher_client.py to allow setting of limits on maximum values of data length, event name length and number of channels.

### DIFF
--- a/pusher/pusher.py
+++ b/pusher/pusher.py
@@ -47,10 +47,11 @@ class Pusher(object):
     def __init__(
             self, app_id, key, secret, ssl=True, host=None, port=None,
             timeout=5, cluster=None, encryption_master_key=None, json_encoder=None, json_decoder=None,
-            backend=None, notification_host=None, notification_ssl=True, **backend_options):
+            backend=None, notification_host=None, notification_ssl=True, max_num_channels=None, 
+            max_len_event_name=None, max_len_data=None, **backend_options):
         self._pusher_client = PusherClient(
             app_id, key, secret, ssl, host, port, timeout, cluster, encryption_master_key,
-            json_encoder, json_decoder, backend, **backend_options)
+            json_encoder, json_decoder, backend, max_num_channels, max_len_event_name, max_len_data, **backend_options)
 
         self._authentication_client = AuthenticationClient(
             app_id, key, secret, ssl, host, port, timeout, cluster, encryption_master_key,

--- a/pusher_tests/test_pusher_client.py
+++ b/pusher_tests/test_pusher_client.py
@@ -89,6 +89,60 @@ class TestPusherClient(unittest.TestCase):
 
             self.assertEqual(request.params, expected_params)
 
+    def test_trigger_fails_when_len_event_name_greater_than_default_and_max_not_specified(self):
+        self.assertRaises(ValueError, lambda: self.pusher_client.trigger.make_request(u'some_channel', u'some_event'*100, {u'message': u'hello worlds'}))
+
+    def test_trigger_success_when_len_event_name_not_greater_than_max_specified(self):
+        json_dumped = u'{"message": "hello worlds"}'
+        pusher_client = PusherClient(app_id=u'4', key=u'key', secret=u'secret', host=u'somehost', max_len_event_name = 5000)
+        with mock.patch('json.dumps', return_value=json_dumped) as json_dumps_mock:
+
+            request = pusher_client.trigger.make_request(u'some_channel', u'some_event'*100, {u'message': u'hello worlds'})
+
+            expected_params = {
+                u'channels': [u'some_channel'],
+                u'data': json_dumped,
+                u'name': u'some_event'*100
+            }
+
+            self.assertEqual(request.params, expected_params)
+
+    def test_trigger_fails_when_num_channels_greater_than_default_and_max_not_specified(self):
+        self.assertRaises(ValueError, lambda: self.pusher_client.trigger.make_request([u'some_channel']*500, u'some_event', {u'message': u'hello worlds'}))
+
+    def test_trigger_success_when_num_channels_not_greater_than_max_specified(self):
+        json_dumped = u'{"message": "hello worlds"}'
+        pusher_client = PusherClient(app_id=u'4', key=u'key', secret=u'secret', host=u'somehost', max_num_channels = 1000)
+        with mock.patch('json.dumps', return_value=json_dumped) as json_dumps_mock:
+
+            request = pusher_client.trigger.make_request([u'some_channel']*500, u'some_event', {u'message': u'hello worlds'})
+
+            expected_params = {
+                u'channels': [u'some_channel']*500,
+                u'data': json_dumped,
+                u'name': u'some_event'
+            }
+
+            self.assertEqual(request.params, expected_params)
+
+    def test_trigger_fails_when_len_data_greater_than_default_and_max_not_specified(self):
+        self.assertRaises(ValueError, lambda: self.pusher_client.trigger.make_request(u'some_channel', u'some_event', {u'message': u'hello worlds'*20000}))
+
+    def test_trigger_success_when_len_data_not_greater_than_max_specified(self):
+        json_dumped = u'{"message": "' + u'hello worlds'*20000 + '"}'
+        pusher_client = PusherClient(app_id=u'4', key=u'key', secret=u'secret', host=u'somehost', max_len_data = 250000)
+        with mock.patch('json.dumps', return_value=json_dumped) as json_dumps_mock:
+
+            request = pusher_client.trigger.make_request(u'some_channel', u'some_event', {u'message': u'hello worlds'*20000})
+
+            expected_params = {
+                u'channels': [u'some_channel'],
+                u'data': json_dumped,
+                u'name': u'some_event'
+            }
+
+            self.assertEqual(request.params, expected_params)
+
     def test_trigger_batch_success_case(self):
         json_dumped = u'{"message": "something"}'
 


### PR DESCRIPTION
Added three new instance attributes for classes Pusher and PusherClient:

- **max_len_data** : Limit on the maximum number of characters in the json dumped string of data (Python dictionary)

- **max_len_event_name** : Limit on the maximum number of characters in the event_name string.

- **max_num_channels** : Limit on the maximum number of channels.

**Note** : Not specifying one or more of the limits will result in the original defaults being used i.e. 10240 for max_len_data, 200 for max_len_event_name and 100 for max_num_channels.

Also added functions in pusher_tests/test_pusher_client.py to test working of limits.