### PR TITLE
Rename Pusher -> Pusher Channels in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ sudo apt-get install build-essential libssl-dev libffi-dev
 ## Getting started
 
 The minimum configuration required to use the Pusher object are the three
-constructor arguments which identify your Pusher app. You can find them by
+constructor arguments which identify your Pusher Channels app. You can find them by
 going to "API Keys" on your app at <https://app.pusher.com>.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ pusher_client = pusher.Pusher(app_id, key, secret, cluster=u'cluster')
 
 |Argument   |Description   |
 |:-:|:-:|
-|app_id `String`  |**Required** <br> The Pusher application ID |
-|key `String`     |**Required** <br> The Pusher application key |
-|secret `String`  |**Required** <br> The Pusher application secret token |
+|app_id `String`  |**Required** <br> The Pusher Channels application ID |
+|key `String`     |**Required** <br> The Pusher Channels application key |
+|secret `String`  |**Required** <br> The Pusher Channels application secret token |
 |cluster `String` | **Default:`mt1`** <br> The pusher application cluster. Will be overwritten if `host` is set |
 |host `String`    | **Default:`None`** <br> The host to connect to |
 |port `int`       | **Default:`None`** <br>Which port to connect to |
@@ -357,7 +357,7 @@ Users can configure the library to use different backends to send calls to our A
 * [AsyncIO](http://asyncio.org/) (`pusher.aiohttp.AsyncIOBackend`).
 * [Google App Engine](https://cloud.google.com/appengine/docs/python/urlfetch/) (`pusher.gae.GAEBackend`).
 
-Upon initializing a Pusher instance, pass in any of these options to the `backend` keyword argument.
+Upon initializing a `Pusher` instance, pass in any of these options to the `backend` keyword argument.
 
 ### Google App Engine
 
@@ -387,7 +387,7 @@ HTTP KeepAlive                             | *&#10008;*
 
 #### Helper Functionality
 
-These are helpers that have been implemented to to ensure interactions with the HTTP API only occur if they will not be rejected e.g. [channel naming conventions](https://pusher.com/docs/client_api_guide/client_channels#naming-channels).
+These are helpers that have been implemented to to ensure interactions with the HTTP API only occur if they will not be rejected e.g. [channel naming conventions](https://pusher.com/docs/channels/using_channels/channels#channel-naming-conventions).
 
 Helper Functionality                     | Supported
 -----------------------------------------| :-------:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ sudo apt-get install build-essential libssl-dev libffi-dev
 
 ## Getting started
 
-The minimum configuration required to use the Pusher object are the three
+ The minimum configuration required to use the `Pusher` object are the three
 constructor arguments which identify your Pusher Channels app. You can find them by
 going to "API Keys" on your app at <https://app.pusher.com>.
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if not VERSION:
 setup(
     name='pusher',
     version=VERSION,
-    description='A Python library to interract with the Pusher API',
+    description='A Python library to interract with the Pusher Channels Channels API',
     url='https://github.com/pusher/pusher-http-python',
     author='Pusher',
     author_email='support@pusher.com',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if not VERSION:
 setup(
     name='pusher',
     version=VERSION,
-    description='A Python library to interract with the Pusher Channels Channels API',
+    description='A Python library to interract with the Pusher Channels API',
     url='https://github.com/pusher/pusher-http-python',
     author='Pusher',
     author_email='support@pusher.com',


### PR DESCRIPTION
The product once called Pusher is now called Pusher Channels.