### PR TITLE
Fix RequestsDependencyWarning by updating requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-
 asn1crypto==0.24.0
 certifi==2019.3.9
 cffi==1.12.3
@@ -14,9 +13,9 @@ pyasn1==0.4.5
 pycparser==2.19
 PyNaCl==1.3.0
 pyOpenSSL==19.0.0
-requests==2.21.0
+requests==2.22.0
 six==1.12.0
-urllib3==1.25.1
+urllib3==1.25.3
 aiohttp==3.5.4; python_version >= '3.5'
 async-timeout==3.0.1; python_version >= '3.5'
 attrs==19.1.0; python_version >= '3.5'


### PR DESCRIPTION
This fixes the `RequestsDependencyWarning`
```
python2.7/site-packages/requests/__init__.py:91: 
RequestsDependencyWarning: urllib3 (1.25.1) or chardet (3.0.4) doesn't match 
a supported version! RequestsDependencyWarning)
```
by upgrading `requests` from `2.21.0` to `2.22.0`. This implies in fact an `urllib3` upgrade from `1.25.1` -> `1.25.3` which resolves the warning.
ref. https://github.com/streamlink/streamlink/issues/2448#issuecomment-487231468

- [x] If you have changed dependencies, ensure _both_ `requirements.txt` and `setup.py` have been updated
