### PR TITLE
Temporary suppress httpretty warnings

### DIFF
--- a/pusher_tests/test_requests_adapter.py
+++ b/pusher_tests/test_requests_adapter.py
@@ -5,10 +5,20 @@ from __future__ import print_function, absolute_import, division
 from pusher import Pusher
 import unittest
 import httpretty
+import sys
 
 class TestRequestsBackend(unittest.TestCase):
 
   def setUp(self):
+
+    # temporary ignoring warnings until these are sorted:
+    # https://github.com/gabrielfalcao/HTTPretty/issues/368
+    # https://github.com/gabrielfalcao/HTTPretty/pull/377
+    if sys.version_info[0] >= 3:
+        import warnings
+        warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed file <_io.BufferedRandom name*")
+        warnings.filterwarnings("ignore", category=PendingDeprecationWarning, message="isAlive*")
+
     self.pusher = Pusher.from_url(u'http://key:secret@api.pusherapp.com/apps/4')
 
   @httpretty.activate


### PR DESCRIPTION
A dependency used:`httpretty` throws:
- `PendingDeprecationWarning` : `httpretty/core.py:438: PendingDeprecationWarning: isAlive() is deprecated, use is_alive() instead if t.isAlive():`
- `ResourceWarning` : `httpretty/core.py:485: ResourceWarning: unclosed file <_io.BufferedRandom name=7> self.fd = FakeSockFile()`

There already are issues and PRs to fix these:
- https://github.com/gabrielfalcao/HTTPretty/issues/368
- https://github.com/gabrielfalcao/HTTPretty/pull/377

Until they are fixed I'm suppressing them as they are noisy and might break or hang CI pipelines as suggested here https://github.com/gabrielfalcao/HTTPretty/issues/368 and here https://github.com/gabrielfalcao/HTTPretty/issues/228