### PR TITLE
Add config parameters to control event trigger constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ pusher_client = pusher.Pusher(app_id, key, secret, cluster=u'cluster')
 |encryption_master_key `String`       | **Default:`None`** <br> The encryption master key for End-to-end Encryption |
 |backend `Object` | an object that responds to the `send_request(request)` method. If none is provided, a `pusher.requests.RequestsBackend` instance is created. |
 |json_encoder `Object` | **Default: `None`**<br> Custom JSON encoder. |
-|json_decoder `Object` | **Default: `None`**<br> Custom JSON decoder.
+|json_decoder `Object` | **Default: `None`**<br> Custom JSON decoder. |
+|max_num_channels `int`   | **Default: `100`**<br> Maximum number of channels that can be triggered at a given time.|
+|max_len_event_name `int` | **Default: `200`**<br> Maximum length of event names.|
+|max_len_data `int`       | **Default: `10240`**<br> Maximum length of data (post JSON serialisation) that can be sent at once.|
 
 The constructor will throw a `TypeError` if it is called with parameters that don’t match the types listed above.
 
@@ -117,7 +120,7 @@ To trigger an event on one or more channels, use the `trigger` method on the `Pu
 |:-:|:-:|
 |buffered_events `Dict`   | A parsed response that includes the event_id for each event published to a channel. See example.   |
 
-`Pusher::trigger` will throw a `TypeError` if called with parameters of the wrong type; or a `ValueError` if called on more than 100 channels, with an event name longer than 200 characters, or with more than 10240 characters of data (post JSON serialisation).
+`Pusher::trigger` will throw a `TypeError` if called with parameters of the wrong type; or a `ValueError` if called on more than `max_num_channels` channels, with an event name longer than `max_len_event_name` characters, or with more than `max_len_data` characters of data (post JSON serialisation). See [Configuration](#configuration) on how to control these constraints and the respective default values.
 
 ##### Example
 

--- a/pusher/pusher.py
+++ b/pusher/pusher.py
@@ -47,10 +47,11 @@ class Pusher(object):
     def __init__(
             self, app_id, key, secret, ssl=True, host=None, port=None,
             timeout=5, cluster=None, encryption_master_key=None, json_encoder=None, json_decoder=None,
-            backend=None, notification_host=None, notification_ssl=True, **backend_options):
+            backend=None, notification_host=None, notification_ssl=True, max_num_channels=None, 
+            max_len_event_name=None, max_len_data=None, **backend_options):
         self._pusher_client = PusherClient(
             app_id, key, secret, ssl, host, port, timeout, cluster, encryption_master_key,
-            json_encoder, json_decoder, backend, **backend_options)
+            json_encoder, json_decoder, backend, max_num_channels, max_len_event_name, max_len_data, **backend_options)
 
         self._authentication_client = AuthenticationClient(
             app_id, key, secret, ssl, host, port, timeout, cluster, encryption_master_key,

--- a/pusher/pusher_client.py
+++ b/pusher/pusher_client.py
@@ -41,8 +41,8 @@ class PusherClient(Client):
             timeout=5, cluster=None,
             encryption_master_key=None,
             json_encoder=None, json_decoder=None,
-            backend=None, max_num_channels = None,
-            max_len_event_name = None, max_len_data = None, **backend_options):
+            backend=None, max_num_channels=None,
+            max_len_event_name=None, max_len_data=None, **backend_options):
         super(PusherClient, self).__init__(
             app_id, key, secret, ssl, host, port, timeout, cluster,
             encryption_master_key, json_encoder, json_decoder,

--- a/pusher/pusher_client.py
+++ b/pusher/pusher_client.py
@@ -41,11 +41,25 @@ class PusherClient(Client):
             timeout=5, cluster=None,
             encryption_master_key=None,
             json_encoder=None, json_decoder=None,
-            backend=None, **backend_options):
+            backend=None, max_num_channels = None,
+            max_len_event_name = None, max_len_data = None, **backend_options):
         super(PusherClient, self).__init__(
             app_id, key, secret, ssl, host, port, timeout, cluster,
             encryption_master_key, json_encoder, json_decoder,
             backend, **backend_options)
+
+        self.max_num_channels = 100
+        self.max_len_event_name = 200
+        self.max_len_data = 10240
+
+        if max_num_channels:
+            self.max_num_channels = max_num_channels
+        
+        if max_len_event_name:
+            self.max_len_event_name = max_len_event_name
+        
+        if max_len_data:
+            self.max_len_data = max_len_data
 
         if host:
             self._host = ensure_text(host, "host")
@@ -71,15 +85,15 @@ class PusherClient(Client):
                 channels, (collections.Sized, collections.Iterable)):
             raise TypeError("Expected a single or a list of channels")
 
-        if len(channels) > 100:
+        if len(channels) > self.max_num_channels:
             raise ValueError("Too many channels")
 
         event_name = ensure_text(event_name, "event_name")
-        if len(event_name) > 200:
+        if len(event_name) > self.max_len_event_name:
             raise ValueError("event_name too long")
 
         data = data_to_string(data, self._json_encoder)
-        if len(data) > 10240:
+        if len(data) > self.max_len_data:
             raise ValueError("Too much data")
 
         channels = list(map(validate_channel, channels))

--- a/pusher/pusher_client.py
+++ b/pusher/pusher_client.py
@@ -48,18 +48,9 @@ class PusherClient(Client):
             encryption_master_key, json_encoder, json_decoder,
             backend, **backend_options)
 
-        self.max_num_channels = 100
-        self.max_len_event_name = 200
-        self.max_len_data = 10240
-
-        if max_num_channels:
-            self.max_num_channels = max_num_channels
-        
-        if max_len_event_name:
-            self.max_len_event_name = max_len_event_name
-        
-        if max_len_data:
-            self.max_len_data = max_len_data
+        self.max_num_channels = max_num_channels if max_num_channels is not None else 100
+        self.max_len_event_name = max_len_event_name if max_len_event_name is not None else 200
+        self.max_len_data = max_len_data if max_len_data is not None else 10240
 
         if host:
             self._host = ensure_text(host, "host")
@@ -130,12 +121,12 @@ class PusherClient(Client):
                 validate_channel(event['channel'])
 
                 event_name = ensure_text(event['name'], "event_name")
-                if len(event['name']) > 200:
+                if len(event['name']) > self.max_len_event_name:
                     raise ValueError("event_name too long")
 
                 event['data'] = data_to_string(event['data'], self._json_encoder)
 
-                if len(event['data']) > 10240:
+                if len(event['data']) > self.max_len_data:
                     raise ValueError("Too much data")
 
                 if is_encrypted_channel(event['channel']):

--- a/pusher_tests/test_pusher_client.py
+++ b/pusher_tests/test_pusher_client.py
@@ -89,6 +89,60 @@ class TestPusherClient(unittest.TestCase):
 
             self.assertEqual(request.params, expected_params)
 
+    def test_trigger_fails_when_len_event_name_greater_than_default_and_max_not_specified(self):
+        self.assertRaises(ValueError, lambda: self.pusher_client.trigger.make_request(u'some_channel', u'some_event'*100, {u'message': u'hello worlds'}))
+
+    def test_trigger_success_when_len_event_name_not_greater_than_max_specified(self):
+        json_dumped = u'{"message": "hello worlds"}'
+        pusher_client = PusherClient(app_id=u'4', key=u'key', secret=u'secret', host=u'somehost', max_len_event_name = 5000)
+        with mock.patch('json.dumps', return_value=json_dumped) as json_dumps_mock:
+
+            request = pusher_client.trigger.make_request(u'some_channel', u'some_event'*100, {u'message': u'hello worlds'})
+
+            expected_params = {
+                u'channels': [u'some_channel'],
+                u'data': json_dumped,
+                u'name': u'some_event'*100
+            }
+
+            self.assertEqual(request.params, expected_params)
+
+    def test_trigger_fails_when_num_channels_greater_than_default_and_max_not_specified(self):
+        self.assertRaises(ValueError, lambda: self.pusher_client.trigger.make_request([u'some_channel']*500, u'some_event', {u'message': u'hello worlds'}))
+
+    def test_trigger_success_when_num_channels_not_greater_than_max_specified(self):
+        json_dumped = u'{"message": "hello worlds"}'
+        pusher_client = PusherClient(app_id=u'4', key=u'key', secret=u'secret', host=u'somehost', max_num_channels = 1000)
+        with mock.patch('json.dumps', return_value=json_dumped) as json_dumps_mock:
+
+            request = pusher_client.trigger.make_request([u'some_channel']*500, u'some_event', {u'message': u'hello worlds'})
+
+            expected_params = {
+                u'channels': [u'some_channel']*500,
+                u'data': json_dumped,
+                u'name': u'some_event'
+            }
+
+            self.assertEqual(request.params, expected_params)
+
+    def test_trigger_fails_when_len_data_greater_than_default_and_max_not_specified(self):
+        self.assertRaises(ValueError, lambda: self.pusher_client.trigger.make_request(u'some_channel', u'some_event', {u'message': u'hello worlds'*20000}))
+
+    def test_trigger_success_when_len_data_not_greater_than_max_specified(self):
+        json_dumped = u'{"message": "' + u'hello worlds'*20000 + '"}'
+        pusher_client = PusherClient(app_id=u'4', key=u'key', secret=u'secret', host=u'somehost', max_len_data = 250000)
+        with mock.patch('json.dumps', return_value=json_dumped) as json_dumps_mock:
+
+            request = pusher_client.trigger.make_request(u'some_channel', u'some_event', {u'message': u'hello worlds'*20000})
+
+            expected_params = {
+                u'channels': [u'some_channel'],
+                u'data': json_dumped,
+                u'name': u'some_event'
+            }
+
+            self.assertEqual(request.params, expected_params)
+
     def test_trigger_batch_success_case(self):
         json_dumped = u'{"message": "something"}'
 


### PR DESCRIPTION
- [x] If you have changed dependencies, ensure _both_ `requirements.txt` and `setup.py` have been updated

Allows customizing Pusher implementation by adding the following parameters to `Pusher` constructor:
  - `max_num_channels`: Maximum number of channels that can be triggered at a given time
  - `max_len_event_name`: Maximum length of event names
  - `max_len_data`: Maximum length of data (post JSON serialisation) that can be sent at once

Updated `README.md` and added tests