### PR TITLE
Fixed SyntaxWarning in py3.8

### DIFF
--- a/pusher/notification_client.py
+++ b/pusher/notification_client.py
@@ -42,7 +42,7 @@ class NotificationClient(Client):
         if not isinstance(interests, list) and not isinstance(interests, set):
             raise TypeError("Interests must be a list or a set")
 
-        if len(interests) is 0:
+        if len(interests) == 0:
             raise ValueError("Interests must not be empty")
 
         if not isinstance(notification, dict):


### PR DESCRIPTION
This prevents the following warning from appearing on Python 3.8:
```
/usr/local/lib/python3.8/site-packages/pusher/notification_client.py:45: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(interests) is 0:
```

- [ ] If you have changed dependencies, ensure _both_ `requirements.txt` and `setup.py` have been updated
