### PR TITLE
Bump httpretty to 0.9.7, remove isAlive warning suppression

### DIFF
--- a/pusher_tests/test_requests_adapter.py
+++ b/pusher_tests/test_requests_adapter.py
@@ -13,11 +13,9 @@ class TestRequestsBackend(unittest.TestCase):
 
     # temporary ignoring warnings until these are sorted:
     # https://github.com/gabrielfalcao/HTTPretty/issues/368
-    # https://github.com/gabrielfalcao/HTTPretty/pull/377
     if sys.version_info[0] >= 3:
         import warnings
         warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed file <_io.BufferedRandom name*")
-        warnings.filterwarnings("ignore", category=PendingDeprecationWarning, message="isAlive*")
 
     self.pusher = Pusher.from_url(u'http://key:secret@api.pusherapp.com/apps/4')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4
 cryptography==2.6.1
-httpretty==0.9.6
+httpretty==0.9.7
 idna==2.8
 mock==2.0.0
 ndg-httpsclient==0.5.1


### PR DESCRIPTION
It bumps the `httpretty` version to `0.9.7`, which fixes the warning on `isAlive`.
ref: https://github.com/gabrielfalcao/HTTPretty/pull/377
