### PR TITLE
Allow client timeout to be a float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.3.1
+
+* [ADDED] Allow Client to accept float as a timeout
+* [ADDED] Tests for Client to validate timeout is a number
+
 ## 3.3.0
 
 - [ADDED] terminate_user_connections method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## 3.3.1
-
-* [ADDED] Allow Client to accept float as a timeout
-* [ADDED] Tests for Client to validate timeout is a number
-
 ## 3.3.0
 
 - [ADDED] terminate_user_connections method

--- a/pusher/client.py
+++ b/pusher/client.py
@@ -60,8 +60,8 @@ class Client(object):
 
         self._port = port or (443 if ssl else 80)
 
-        if not isinstance(timeout, six.integer_types):
-              raise TypeError("timeout should be an integer")
+        if not (isinstance(timeout, six.integer_types) or isinstance(timeout, float)):
+              raise TypeError("timeout should be an integer or a float")
 
         self._timeout = timeout
         self._json_encoder = json_encoder

--- a/pusher_tests/test_client.py
+++ b/pusher_tests/test_client.py
@@ -55,6 +55,13 @@ class TestClient(unittest.TestCase):
         self.assertRaises(TypeError, lambda: Client(
             app_id=u'4', key=u'key', secret=u'secret', ssl=True, port=u'400'))
 
+    def test_timeout_should_be_number(self):
+        Client(app_id=u'4', key=u'key', secret=u'secret', timeout=1)
+        Client(app_id=u'4', key=u'key', secret=u'secret', timeout=3.14)
+
+        self.assertRaises(TypeError, lambda: Client(
+            app_id=u'4', key=u'key', secret=u'secret', timeout=u'1'))
+
 
     def test_port_behaviour(self):
         conf = Client(app_id=u'4', key=u'key', secret=u'secret', ssl=True)


### PR DESCRIPTION
## What does this PR do?

Allow the client to accept a float as a timeout. 

The underlying `requests` library used by pusher allows floats to be used when making requests. (see https://requests.readthedocs.io/en/latest/api/#requests.request)

Related issue: https://github.com/pusher/pusher-http-python/issues/194


## CHANGELOG

- [ADDED] Allow Client to accept float as a timeout
- [CHANGED] the maximum event payload size permitted by this library has been increased. This change affects the library only: the Channels API still maintains a 10kb size limit and will return an error if the payload is too large.