### PR TITLE
increase the size of the local payload check

### DIFF
--- a/pusher/pusher_client.py
+++ b/pusher/pusher_client.py
@@ -91,7 +91,7 @@ class PusherClient(Client):
             raise ValueError("event_name too long")
 
         data = data_to_string(data, self._json_encoder)
-        if sys.getsizeof(data) > 10240:
+        if sys.getsizeof(data) > 30720:
             raise ValueError("Too much data")
 
         channels = list(map(validate_channel, channels))

--- a/pusher_tests/test_pusher_client.py
+++ b/pusher_tests/test_pusher_client.py
@@ -207,7 +207,7 @@ class TestPusherClient(unittest.TestCase):
     def test_trigger_too_much_data(self):
         pc = PusherClient(app_id=u'4', key=u'key', secret=u'secret', ssl=True)
 
-        self.assertRaises(ValueError, lambda: pc.trigger(u'private-tst', u'some_event', u'a' * 10241))
+        self.assertRaises(ValueError, lambda: pc.trigger(u'private-tst', u'some_event', u'a' * 30721))
 
     def test_trigger_batch_too_much_data(self):
         pc = PusherClient(app_id=u'4', key=u'key', secret=u'secret', ssl=True)
@@ -215,15 +215,15 @@ class TestPusherClient(unittest.TestCase):
         self.assertRaises(ValueError, lambda: pc.trigger_batch(
             [{u'channel': u'private-tst', u'name': u'some_event', u'data': u'a' * 30721}]))
 
-    def test_trigger_str_shorter_than_10240_but_more_than_10kb_raising(self):
+    def test_trigger_str_shorter_than_30720_but_more_than_3kb_raising(self):
         pc = PusherClient(app_id=u'4', key=u'key', secret=u'secret', ssl=True)
 
-        self.assertRaises(ValueError, lambda: pc.trigger.make_request(u'private-tst', u'some_event', u'你' * 10000))
+        self.assertRaises(ValueError, lambda: pc.trigger.make_request(u'private-tst', u'some_event', u'你' * 30000))
 
-    def test_trigger_batch_str_shorter_than_10240_but_more_than_10kb_raising(self):
+    def test_trigger_batch_str_shorter_than_30720_but_more_than_30kb_raising(self):
         pc = PusherClient(app_id=u'4', key=u'key', secret=u'secret', ssl=True)
 
-        self.assertRaises(ValueError, lambda: pc.trigger_batch.make_request([{u'channel': u'private-tst', u'name': u'some_event', u'data': u'你' * 10000}]))
+        self.assertRaises(ValueError, lambda: pc.trigger_batch.make_request([{u'channel': u'private-tst', u'name': u'some_event', u'data': u'你' * 30000}]))
 
     def test_trigger_with_public_channel_with_encryption_master_key_specified_success(self):
         json_dumped = u'{"message": "something"}'

--- a/pusher_tests/test_pusher_client.py
+++ b/pusher_tests/test_pusher_client.py
@@ -213,7 +213,7 @@ class TestPusherClient(unittest.TestCase):
         pc = PusherClient(app_id=u'4', key=u'key', secret=u'secret', ssl=True)
 
         self.assertRaises(ValueError, lambda: pc.trigger_batch(
-            [{u'channel': u'private-tst', u'name': u'some_event', u'data': u'a' * 10241}]))
+            [{u'channel': u'private-tst', u'name': u'some_event', u'data': u'a' * 30721}]))
 
     def test_trigger_str_shorter_than_10240_but_more_than_10kb_raising(self):
         pc = PusherClient(app_id=u'4', key=u'key', secret=u'secret', ssl=True)


### PR DESCRIPTION
## What does this PR do?

Increases the size limit of the event payload in the local checks. This prevents two issues: 
- sys.getsizeof calculates the size of the payload in memory, which can be larger that the size of the payload in the network HTTP request. This means some payloads are incorrectly blocked by this check. 
- some dedicated clusters have a higher max payload size. This library in its current format does not support such clusters. 

This change is safe as the API already checks the size of events and returns an error if too large. 

- [ ] If you have changed dependencies, ensure _both_ `requirements.txt` and `setup.py` have been updated

## CHANGELOG

- [CHANGED] the maximum event payload size permitted by this library has been increased. This change affects the library only: the Channels API still maintains a 10kb size limit and will return an error if the payload is too large. 