### PR TITLE
Prepare 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.3.1
+
+- [ADDED] Allow Client to accept float as a timeout
+- [CHANGED] the maximum event payload size permitted by this library has been increased. This change affects the library only: the Channels API still maintains a 10kb size limit and will return an error if the payload is too large.
+
 ## 3.3.0
 
 - [ADDED] terminate_user_connections method

--- a/pusher/util.py
+++ b/pusher/util.py
@@ -17,12 +17,10 @@ app_id_re = re.compile(r'\A[0-9]+\Z')
 pusher_url_re = re.compile(r'\A(http|https)://(.*):(.*)@(.*)/apps/([0-9]+)\Z')
 socket_id_re = re.compile(r'\A\d+\.\d+\Z')
 
-
 if sys.version_info < (3,):
     text = 'a unicode string'
 else:
     text = 'a string'
-
 
 if sys.version_info < (3,):
     byte_type = 'a python2 str'

--- a/pusher/version.py
+++ b/pusher/version.py
@@ -1,2 +1,2 @@
 # Don't change the format of this line: the version is extracted by ../setup.py
-VERSION = '3.3.0'
+VERSION = '3.3.1'


### PR DESCRIPTION
## What does this PR do?

Prepare release with #195 and #198 

## CHANGELOG

- [ADDED] Allow Client to accept float as a timeout
- [CHANGED] the maximum event payload size permitted by this library has been increased. This change affects the library only: the Channels API still maintains a 10kb size limit and will return an error if the payload is too large.