### PR TITLE
Json ensure ascii false

### DIFF
--- a/pusher/util.py
+++ b/pusher/util.py
@@ -110,7 +110,7 @@ def data_to_string(data, json_encoder):
         return ensure_text(data, "data")
 
     else:
-        return json.dumps(data, cls=json_encoder)
+        return json.dumps(data, cls=json_encoder, ensure_ascii=False)
 
 
 def doc_string(doc):


### PR DESCRIPTION
## What does this PR do?

- Prevent escaping utf-8 characters to their unicode code point equivalent which inflates message size.

## CHANGELOG

- [CHANGED] Add ensure_ascii=False to JSON serialization
