### PR TITLE
Prepare 3.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.2
+
+- [CHANGED] Utilities no longer escape non ascii characters. 
+
 ## 3.3.1
 
 - [ADDED] Allow Client to accept float as a timeout

--- a/README.md
+++ b/README.md
@@ -441,3 +441,4 @@ To run the tests run `python setup.py test`
 ## License
 
 Copyright (c) 2015 Pusher Ltd. See [LICENSE](LICENSE) for details.
+

--- a/pusher/version.py
+++ b/pusher/version.py
@@ -1,2 +1,2 @@
 # Don't change the format of this line: the version is extracted by ../setup.py
-VERSION = '3.3.1'
+VERSION = '3.3.2'


### PR DESCRIPTION
## What does this PR do?

Prepare release with https://github.com/pusher/pusher-http-python/pull/200

## CHANGELOG

- [CHANGED] Utilities no longer escape non ascii characters. 
