### PR TITLE
Remove explicit app_id format validator

### DIFF
--- a/pusher/client.py
+++ b/pusher/client.py
@@ -8,7 +8,7 @@ from __future__ import (
 
 import six
 
-from pusher.util import ensure_text, ensure_binary, app_id_re
+from pusher.util import ensure_text, ensure_binary
 from pusher.crypto import parse_master_key
 
 
@@ -35,9 +35,6 @@ class Client(object):
               backend = RequestsBackend
 
         self._app_id = ensure_text(app_id, "app_id")
-        if not app_id_re.match(self._app_id):
-              raise ValueError("Invalid app id")
-
         self._key = ensure_text(key, "key")
         self._secret = ensure_text(secret, "secret")
 


### PR DESCRIPTION
I've never seen such validation on PHP or event on Go client. The same app_id which works fine on other clients, but not on python due to this exceptional checking.

## What does this PR do?

You can use string app_id on python client. Similar to PHP or Go. 

## CHANGELOG

- Removed extra number validation on app_id
