### PR TITLE
Incorrect usage of sys.getsizeof to calculate the byte size of event data

### DIFF
--- a/pusher/pusher_client.py
+++ b/pusher/pusher_client.py
@@ -130,7 +130,7 @@ class PusherClient(Client):
 
                 event['data'] = data_to_string(event['data'], self._json_encoder)
 
-                if sys.getsizeof(event['data']) > 10240:
+                if len(event['data'].encode('utf-8')) > 10240:
                     raise ValueError("Too much data")
 
                 if is_encrypted_channel(event['channel']):


### PR DESCRIPTION
[Incorrect usage of sys.getsizeof to calculate the byte size of event data
Fixes #236

## What does this PR do?
As stated in the raised bug, the usage of sys.getsizeof function for getting the size of event_data was incorrect. Hence, I changed it to len.

- [.] If you have changed dependencies, ensure _both_ `requirements.txt` and `setup.py` have been updated

## CHANGELOG

- [CHANGED] Describe your change here. Look at CHANGELOG.md to see the format.
